### PR TITLE
이력서 기반 생성 질문 분리

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,8 @@ from module.openai_summarize import summarize_text
 from module.pose_feedback import consolidate_feedback
 from module.openai_speaking import evaluate_speaking
 from module import openai_behavioral
+from module.openai_resumeTech import technical_resume
+from module.openai_resumBehav import behavioral_resume
 # from module.pose_feedback import consolidate_feedback
 
 app = FastAPI()
@@ -293,3 +295,65 @@ async def websocket_endpoint(websocket: WebSocket):
         (f"WebSocket error: {str(e)}")
     finally:
         ("WebSocket connection closed")
+
+@app.post("/technical_resume")
+async def create_upload_file(
+    job: str = Form(...),
+    years: str = Form(...),
+    file: UploadFile = File(None)
+):
+    if not job or not years:
+        raise HTTPException(status_code=400, detail="직업군과 연차는 필수 입력 항목입니다.")
+
+    pdf_content = None
+    if file:
+        with NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
+            shutil.copyfileobj(file.file, temp_file)
+            pdf_content = temp_file.name
+
+    print(f"직업군: {job}, 연차: {years}")
+    if pdf_content:
+        print(f"PDF 파일 저장 경로: {pdf_content}")
+
+    result = technical_resume(job, years, pdf_content)
+
+    # PDF 파일 삭제
+    if pdf_content:
+        try:
+            os.remove(pdf_content)
+            print(f"PDF 파일 삭제 완료: {pdf_content}")
+        except Exception as e:
+            print(f"PDF 파일 삭제 실패: {e}")
+            
+    return JSONResponse(content=result)
+
+@app.post("/behavioral_resume")
+async def create_upload_file_behavioral(
+    job: str = Form(...),
+    years: str = Form(...),
+    file: UploadFile = File(None)
+):
+    if not job or not years:
+        raise HTTPException(status_code=400, detail="직업군과 연차는 필수 입력 항목입니다.")
+
+    pdf_content = None
+    if file:
+        with NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
+            shutil.copyfileobj(file.file, temp_file)
+            pdf_content = temp_file.name
+
+    print(f"직업군: {job}, 연차: {years}")
+    if pdf_content:
+        print(f"PDF 파일 저장 경로: {pdf_content}")
+
+    result = behavioral_resume(job, years, pdf_content)
+
+    # PDF 파일 삭제
+    if pdf_content:
+        try:
+            os.remove(pdf_content)
+            print(f"PDF 파일 삭제 완료: {pdf_content}")
+        except Exception as e:
+            print(f"PDF 파일 삭제 실패: {e}")
+            
+    return JSONResponse(content=result)

--- a/module/openai_resumBehav.py
+++ b/module/openai_resumBehav.py
@@ -1,0 +1,114 @@
+from openai import OpenAI
+import os
+from dotenv import load_dotenv
+from langchain.document_loaders import PyPDFLoader
+import json
+
+def behavioral_resume(job, years, pdf_file=None, max_retries=3):
+    load_dotenv()
+    api_key = os.getenv("API_KEY")
+    if api_key is None:
+        raise ValueError("API_KEY가 없습니다.")
+
+    client = OpenAI(api_key=api_key)
+
+    resume_content = ""
+    if pdf_file:
+        loader = PyPDFLoader(pdf_file)
+        document = loader.load()
+        resume_content = "\n".join([page.page_content for page in document])
+
+    # 이력서가 없는 경우의 프롬프트
+    prompt_without_resume = f"""
+    # Role
+    You are a professional interviewer specializing in assessing behavioral aspects.
+
+    # Task
+    1. Please create 50 expected questions for the ({job})'s ({years})th year personality interview.
+    2. Randomly choose 2 questions from the 50 you created.
+
+    # Policy
+    - Focus primarily on assessing the applicant's personality, values, and teamwork skills.
+    - Do not duplicate questions that have the same meaning.
+    - Generate questions only in Korean.
+    - Responses must be in JSON format.
+    - Do not include any additional explanations beyond the specified output format.
+
+    # Output Format
+    {{
+        "Q6": "",
+        "Q7": ""
+    }}
+    """
+
+    # 이력서가 있는 경우의 프롬프트
+    prompt_with_resume = f"""
+    # Role
+    You are a professional interviewer specializing in assessing behavioral aspects.
+
+    # Task
+    1. Please create 50 expected questions for the ({job})'s ({years})th year personality interview based on the resume content.
+    2. Randomly choose 2 questions from the 50 you created.
+
+    # Policy
+    - Focus primarily on assessing the applicant's personality, values, and teamwork skills.
+    - Do not duplicate questions that have the same meaning.
+    - Generate questions only in Korean.
+    - Responses must be in JSON format.
+    - Do not include any additional explanations beyond the specified output format.
+
+    # Output Format
+    {{
+        "Q6": "",
+        "Q7": ""
+    }}
+    
+    Resume content:
+    {resume_content}
+    """
+
+    def get_questions(prompt):
+        for attempt in range(max_retries):
+            try:
+                completion = client.chat.completions.create(
+                    model=os.getenv("gpt"),
+                    messages=[
+                        {"role": "system", "content": "You are a professional interviewer specializing in assessing behavioral aspects."},
+                        {"role": "user", "content": prompt}
+                    ],
+                    temperature=0.5
+                )
+                response_content = completion.choices[0].message.content
+                questions = json.loads(response_content)
+                
+                # 응답을 Q6와 Q7 형식으로 강제 변환
+                formatted_questions = {}
+                question_keys = list(questions.keys())
+                if len(question_keys) >= 2:
+                    formatted_questions["Q6"] = questions[question_keys[0]]
+                    formatted_questions["Q7"] = questions[question_keys[1]]
+                else:
+                    raise ValueError("Not enough questions in the response")
+                
+                return formatted_questions
+            except (json.JSONDecodeError, ValueError, KeyError):
+                if attempt < max_retries - 1:
+                    prompt += "\n\nYour previous response was not in the correct format. Please ensure you respond with a valid JSON object containing exactly two questions."
+                else:
+                    return None
+        return None
+
+    # 이력서 유무에 따라 적절한 프롬프트 선택
+    selected_prompt = prompt_with_resume if pdf_file else prompt_without_resume
+
+    questions = get_questions(selected_prompt)
+
+    if questions is None:
+        # If all attempts fail, return a default structure
+        default_questions = {
+            "Q6": "여섯 번째 질문을 생성하는 데 문제가 발생했습니다.",
+            "Q7": "일곱 번째 질문을 생성하는 데 문제가 발생했습니다."
+        }
+        return default_questions
+    
+    return questions

--- a/module/openai_resumeTech.py
+++ b/module/openai_resumeTech.py
@@ -1,0 +1,127 @@
+from openai import OpenAI
+import os
+from dotenv import load_dotenv
+from langchain.document_loaders import PyPDFLoader
+# from elasticsearch import Elasticsearch
+import json
+
+def technical_resume(job, years, pdf_file=None, max_retries=3):
+    load_dotenv()
+    api_key = os.getenv("API_KEY")
+    if api_key is None:
+        raise ValueError("API_KEY가 없습니다.")
+
+    client = OpenAI(api_key=api_key)
+
+    resume_content = ""
+    if pdf_file:
+        loader = PyPDFLoader(pdf_file)
+        document = loader.load()
+        resume_content = "\n".join([page.page_content for page in document])
+
+    # 이력서가 없는 경우의 프롬프트
+    prompt_without_resume = f"""
+    # Role
+    You are the interviewer.
+    # Task
+    Create technical questions based on the following criteria:
+    - User experience level: {years} years
+    - User role: {job}
+
+    # Instructions
+    - Generate 50 unique (non-duplicate) technical questions based on the user's role and experience level.
+    - Ensure that questions are relevant, clear, and focused on assessing technical knowledge.
+    - Questions should be answerable through verbal explanation.
+    - Write your questions in Korean only.
+    - Construct questions at a level appropriate for the years of experience provided.
+    - Do not ask for code examples.
+    - Randomly choose 2 out of 50 questions you created
+    - Output only the selected 2 questions.
+
+    # Output Format
+    You must **strictly** adhere to the following JSON format:
+    {{
+        "Q6": "Your sixth question based on role and experience",
+        "Q7": "Your seventh question based on role and experience"
+    }}
+    """
+
+    # 이력서가 있는 경우의 프롬프트
+    prompt_with_resume = f"""
+    # Role
+    You are the interviewer.
+
+    # Task
+    Create technical questions based on the following criteria:
+    - User experience level: {years} years
+    - User role: {job}
+
+    # Instructions
+    - Generate 50 unique (non-duplicate) technical questions based on the resume content.
+    - Focus these questions on specific projects, technologies, or experiences mentioned in the resume.
+    - Select a project from the resume that is related to the user's role ({job}) and create two technical questions based on that project.
+    - Randomly choose 2 questions from the 50 you created.
+    - If the resume includes experiences that do not match the user's role ({job}), ignore them and choose projects and technologies that align with the given role.
+    - Questions should be relevant, clear, and focused on assessing technical knowledge.
+    - Questions should be answerable through verbal explanation.
+    - Write your questions in Korean only.
+    - Construct questions at a level appropriate for the years of experience provided.
+    - Do not ask for code examples.
+    - Output only the selected 2 questions.
+
+    # Output Format
+    You must **strictly** adhere to the following JSON format:
+    {{
+        "Q6": "Your sixth question based on role and experience",
+        "Q7": "Your seventh question based on role and experience"
+    }}
+    
+    Resume content:
+    {resume_content}
+    """
+
+    def get_questions(prompt):
+        for attempt in range(max_retries):
+            try:
+                completion = client.chat.completions.create(
+                    model=os.getenv("gpt"),
+                    messages=[
+                        {"role": "system", "content": "You are the interviewer, you are a professional developer. You must always respond in the specified JSON format."},
+                        {"role": "user", "content": prompt}
+                    ],
+                    temperature=0.5
+                )
+                response_content = completion.choices[0].message.content
+                questions = json.loads(response_content)
+                
+                # 응답을 Q6와 Q7 형식으로 강제 변환
+                formatted_questions = {}
+                question_keys = list(questions.keys())
+                if len(question_keys) >= 2:
+                    formatted_questions["Q6"] = questions[question_keys[0]]
+                    formatted_questions["Q7"] = questions[question_keys[1]]
+                else:
+                    raise ValueError("Not enough questions in the response")
+                
+                return formatted_questions
+            except (json.JSONDecodeError, ValueError, KeyError):
+                if attempt < max_retries - 1:
+                    prompt += "\n\nYour previous response was not in the correct format. Please ensure you respond with a valid JSON object containing exactly two questions."
+                else:
+                    return None
+        return None
+
+    # 이력서 유무에 따라 적절한 프롬프트 선택
+    selected_prompt = prompt_with_resume if pdf_file else prompt_without_resume
+
+    questions = get_questions(selected_prompt)
+
+    if questions is None:
+        # If all attempts fail, return a default structure
+        default_questions = {
+            "Q6": "여섯 번째 질문을 생성하는 데 문제가 발생했습니다.",
+            "Q7": "일곱 번째 질문을 생성하는 데 문제가 발생했습니다."
+        }
+        return default_questions
+    
+    return questions


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🔑 주요 변경사항
- main.py에 새로운 주소로 이력서기반 질문생성 부분 추가
- 이력서 없을시 경력, 직업으로 2개 이력서 있을시 이력서 기반 2개 생성
- Q6,Q7고정으로 생성 
- 말씀하신대로 이름 맞추어서 새로 폴더 만들어서 작업했습니다

### 🏞 스크린샷
<img width="2557" alt="스크린샷 2024-09-15 오후 2 52 07" src="https://github.com/user-attachments/assets/548e2a0e-6fb5-413a-bfe6-7905eb52817b">
<img width="2560" alt="스크린샷 2024-09-15 오후 2 53 46" src="https://github.com/user-attachments/assets/6547a3f5-d8bb-4b61-a7fc-0d06ae519406">

